### PR TITLE
Support SyntaxError for browserify too

### DIFF
--- a/bin/build-error-notifier.js
+++ b/bin/build-error-notifier.js
@@ -8,7 +8,7 @@ var argv = require('minimist')(process.argv.slice(2))
 
 var config = {
   'browserify': {
-    regex: /Error:\sParsing\sfile\s(?:.*\/)*(.*.js):\s(.*)\s\((.*)\)/,
+    regex: /(?:(?:Error:\sParsing\sfile)|(?:SyntaxError:))\s(?:.*\/)*(.*.js):\s(.*)\s\((.*)\)/,
     title: 'Browserify',
     subtitle: '{{{2}}}',
     message: '{{{1}}} [{{{3}}}]',


### PR DESCRIPTION
I noticed that browserify was actually producing errors like this...

SyntaxError: /Users/user_name/Sites/project/src/app.js: Unexpected token, expected jsxTagEnd (15:38) while parsing file: 

... so I've changed the regex to match both. It uses non-capturing groups and a boolean.

Feel free to edit to add to the test file before merging. I didn't have time :(